### PR TITLE
feat(api): read base URL from VITE_API_BASE_URL with localhost fallback (#2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Base URL for the API the frontend talks to. Change this when
+# pointing at staging or production.
+#
+# Vite only exposes variables prefixed with `VITE_` to client-side
+# code; do not rename without also updating src/api/axiosConfig.js.
+VITE_API_BASE_URL=http://127.0.0.1:4000

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Local environment files. .env.example stays in the repo as a template.
+.env
+.env.local
+.env.*.local
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/api/axiosConfig.js
+++ b/src/api/axiosConfig.js
@@ -1,6 +1,13 @@
 import axios from "axios";
+
+// VITE_API_BASE_URL is the only knob for switching environments
+// (local, staging, production). Keep `http://127.0.0.1:4000` as the
+// fallback so a fresh checkout without an .env still hits the local
+// dev server. See .env.example for the documented variable.
+const baseURL = import.meta.env.VITE_API_BASE_URL || 'http://127.0.0.1:4000';
+
 const axiosClient = axios.create({
-    baseURL: 'http://127.0.0.1:4000',
+    baseURL,
     headers: { 'content-type': 'application/json'}
 })
 


### PR DESCRIPTION
Closes #2.

## Summary
- The axios client in \`src/api/axiosConfig.js\` had its base URL hard-coded to \`http://127.0.0.1:4000\`, so switching between local, staging, and production required editing source.
- Move it behind the Vite env var \`VITE_API_BASE_URL\` (Vite only exposes \`VITE_*\` variables to client code).
- Fall back to \`http://127.0.0.1:4000\` when the env var is missing, so a fresh checkout without an .env still hits the local dev server.
- Add \`.env.example\` documenting the variable, and update \`.gitignore\` to ignore local \`.env\` / \`.env.local\` / \`.env.*.local\` files. \`.env.example\` stays in the repo as the template, per the issue request.

## Verification
- [x] \`npm install\` clean.
- [x] \`npm run build\` produces the same dist output as before (95 modules transformed, identical entry/css sizes within rounding).
- [x] Default behavior unchanged: with no .env present, the axios client points at \`http://127.0.0.1:4000\` exactly as before.

## Usage
```bash
cp .env.example .env
# edit .env with your environment's URL, e.g.:
# VITE_API_BASE_URL=https://api.staging.example.com
npm run dev
```